### PR TITLE
Add infix functions, and the require keyword.

### DIFF
--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -133,8 +133,10 @@ instance Pretty (UModule' PhCheck) where
   pretty (RefModule _ _ v) = absurd v
 
 instance Pretty (UModuleDep' PhCheck) where
-  pretty (UModuleDep name renamingBlocks) =
-    p name <+> align (vsep (map p renamingBlocks)) <> ";"
+  pretty (UModuleDep name renamingBlocks castToSig) =
+    let pName = if castToSig then "signature(" <+> p name <+> ")"
+                             else p name
+    in pName <+> align (vsep (map p renamingBlocks)) <> ";"
 
 instance Pretty (URenamingBlock' PhCheck) where
   pretty (URenamingBlock renamings) =

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -133,7 +133,9 @@ data UModule' p = UModule UModuleType Name (XPhasedContainer p (UDecl p)) (XPhas
 
 -- Expose out for DAG building
 type UModuleDep p = Ann p UModuleDep'
-data UModuleDep' p = UModuleDep Name [URenamingBlock p]
+-- Represents a dependency to a module with an associated list of renaming
+-- blocks, as well as whether to only extract the signature of the dependency.
+data UModuleDep' p = UModuleDep Name [URenamingBlock p] Bool
 
 type URenamingBlock p = Ann p URenamingBlock'
 newtype URenamingBlock' p = URenamingBlock [URenaming p]
@@ -354,7 +356,7 @@ instance NamedNode (USatisfaction' p) where
   nodeName (USatisfaction name _ _ _) = name
 
 instance NamedNode (UModuleDep' p) where
-  nodeName (UModuleDep name _) = name
+  nodeName (UModuleDep name _ _) = name
 
 instance NamedNode (UDecl p) where
   nodeName decl = case decl of

--- a/src/magnolia.hs
+++ b/src/magnolia.hs
@@ -42,8 +42,10 @@ main = do
     BuildMode filename -> build filename >>= pprint
 
 codegen :: String -> TopEnv -> IO String -- TODO: return instead source code type or smth
-codegen filename env = case M.lookup (PkgName filename) env of
-  Nothing -> error "Compiler bug!" -- TODO: handle dir paths better
+codegen filename env = case M.lookup (mkPkgNameFromPath filename) env of
+  Nothing -> error $ "Compiler bug! Package for file " <> filename <>
+    " not found."
+  -- TODO: handle dir paths better
   Just pkg -> return (emitPyPackage pkg)
 
 -- TODO: add existing env, and move "compile" to Make module


### PR DESCRIPTION
More specifically, the changes in this commit are the following:

* add infix functions on predicates, accessible in every module;
* generate an equality function for every new declared type;
* implement the 'require' keyword and the ability to reduce a module to
  its signature;
* fix some minor bugs in the compiler.

Note that the infix functions on the predicates are now hardcoded in
the compiler. It is likely that this is not how we want to implement
this in the long run. However, since this is somewhat of a blocker and
since that part of the design has not been finalized, we implement it
like so for the moment.