### PR TITLE
Set up testing and continuous integration for the repository.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: Haskell CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: 'latest'
+        cabal-version: 'latest'
+
+    - name: Cache
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install dependencies
+      run: |
+        cabal update
+        cabal build --only-dependencies --enable-tests --enable-benchmarks
+    - name: Build
+      run: make
+    - name: Run tests
+      run: make tests

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+mgn := cabal exec magnolia --
+
 build:
 	cabal new-build
 
@@ -7,5 +9,17 @@ clean:
 lint:
 	hlint src
 
-add:
-	find src -name "*.hs" | xargs git add
+test-targets = parsing-recovery
+
+tests: $(test-targets:%=check-output-%)
+
+update-tests: $(test-targets:%=update-output-%)
+
+check-output-%: tests/inputs/%.mg tests/outputs/%.mg.out build
+	$(eval tempfile := $(shell mktemp))
+	$(mgn) build $< > $(tempfile)
+	@diff $(tempfile) $(word 2, $^) > /dev/null && echo "OK" || (echo "Output is not matching for test file $<"; rm $(tempfile); exit 1)
+	@rm $(tempfile)
+
+update-output-%: tests/inputs/%.mg build
+	$(mgn) build $< > tests/outputs/$(notdir $<).out

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A very simplistic Makefile is provided, and the following should be sufficient
 to get going:
 
 ```bash
-$ make build
-$ # to get a symlink to the executable at the root of the repo, you can run
-$ find dist-newstyle/ -name magnolia -type f | xargs -I % sh -c 'ln -s % magnolia'
+make build
+# For convenience, you may define an alias for the compiler
+alias magnolia='cabal exec magnolia --'
 ```
 
 ## How to build Magnolia programs
@@ -20,7 +20,7 @@ Right now, code generation is very much incomplete; the output is pretty much
 useless. However, running
 
 ```bash
-$ ./magnolia build <path/to/package.mg>
+magnolia build <path/to/package.mg>
 ```
 
 will go through the compilation steps, and will output typechecking/parsing
@@ -30,7 +30,7 @@ Another option to explore Magnolia source files is to explore them using the
 `repl` option instead:
 
 ```bash
-$ ./magnolia repl
+magnolia repl
 mgn> help
 Available commands are:
         help: show this help menu
@@ -66,7 +66,7 @@ we can discuss them.
 #### Missing features
 
 - [ ] Satisfactions handling
-- [ ] Tests for the code and CI
+- [ ] Extensive testing of the compiler
 - [ ] Code generation
 - [ ] Documentation (*the code base is small, so it is not yet critical*)
 - [ ] Distinction between "normal" blocks and value blocks

--- a/tests/inputs/parsing-recovery.mg
+++ b/tests/inputs/parsing-recovery.mg
@@ -1,0 +1,1 @@
+package

--- a/tests/outputs/parsing-recovery.mg.out
+++ b/tests/outputs/parsing-recovery.mg.out
@@ -1,0 +1,7 @@
+<no context>: Parse error: tests/inputs/parsing-recovery.mg:2:1:
+  |
+2 | <empty line>
+  | ^
+unexpected end of input
+expecting '_' or alphanumeric character
+


### PR DESCRIPTION
Set up testing and continuous integration for the repository.
    
The Makefile now exposes a few more relevant commands:
- `tests` – which runs all the unit tests and checks that their output is as expected;
- `update-tests` – which reruns all the unit tests and updates their expected outputs;
- `check-output-$(testname)` – which runs one specific unit test;
- `update-output-$(testname)` – which updates the expected output of a specific unit test.
    
Unit tests consist of two files:
- a Magnolia package `tests.inputs.$filename`, stored in `tests/inputs/$filename.mg`;
- the expected output of the compilation of tests.inputs.$filename, stored in `tests/outputs/$filename.mg.out`.
    
Since tests can consist of multiple files, the explicit test targets must be manually added to the `test-targets` variable in the Makefile.

The only test right now, `parsing-recovery`, is given as an example.