### PR TITLE
Implement variable assignment as a procedure call.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-mgn := cabal exec magnolia --
+mgn := cabal exec -v0 magnolia --
 
 build:
 	cabal new-build
@@ -9,7 +9,7 @@ clean:
 lint:
 	hlint src
 
-test-targets = parsing-recovery
+test-targets = parsing-recovery stmtErrors
 
 tests: $(test-targets:%=check-output-%)
 

--- a/tests/inputs/stmtErrors.mg
+++ b/tests/inputs/stmtErrors.mg
@@ -1,0 +1,20 @@
+package tests.inputs.stmtErrors;
+
+// TODO: expand with tests for all the statements/expressions
+
+implementation StmtTests = {
+    require type T1;
+    require type T2;
+
+    require function mkT1(): T1;
+    require function mkT2(): T2;
+
+    procedure tests() {
+        var t1 = mkT1();
+        // == assignment statement tests ==
+        // Valid assignment
+        t1 = mkT1();
+        // Invalid assignment
+        t1 = mkT2();
+    }
+};

--- a/tests/outputs/stmtErrors.mg.out
+++ b/tests/outputs/stmtErrors.mg.out
@@ -1,0 +1,1 @@
+tests/inputs/stmtErrors.mg:18:9: Error: function not in scope: _=_ with arguments of type (T1, T2)


### PR DESCRIPTION
For every type, a procedure `_=_(out var, obs expr)` is generated. A
parsing rule for `_=_` has been added as well.

Note that `_=_` is not overloadable/implementable from user code, at the
moment.