### PR TITLE
Disambiguate properly between {im,}mutable evaluation contexts.

### DIFF
--- a/tests/inputs/modeCheck.mg
+++ b/tests/inputs/modeCheck.mg
@@ -28,6 +28,16 @@ implementation modeCheck_I = {
     procedure call_upd_upd(upd in: T) = call in_upd(in); // should succeed
 
     // test mismatch across several arguments
-    procedure in_2_obs(obs in1: T, obs in2: T);
-    procedure call_out_2_obs(out in: T) = call in_2_obs(in, in);
+    procedure in_2_obs(obs in1: T, obs in2: T); // should fail
+    procedure call_out_2_obs(out in: T) = call in_2_obs(in, in); // should fail
+
+    // various attempts to read out variables
+    procedure value_out(out in: T) { value in; } // should fail
+    procedure assign_out(out in: T) { var v = in; } // should fail
+
+    // check that after being set, previously out variables can be set
+    procedure read_from_assigned_out(out in: T) { // should succeed
+        call in_out(in);
+        var v = in;
+    }
 }

--- a/tests/inputs/stateHandlingTests.mg
+++ b/tests/inputs/stateHandlingTests.mg
@@ -10,6 +10,11 @@ implementation I = {
     // Stateful computation using an effectful block, should succeed
     procedure stateful_ctx_effect(obs t: T) { t; }
 
+    // Value block attempting to return values of different types, should fail
+    function value_block_inconsistent_types(t: T, u: U): T {
+        value t; value u;
+    }
+
     // Value block attempting to update the outer environment, should fail
     procedure value_block_attempting_side_effect(obs t: T) {
         var out_t: T;
@@ -19,8 +24,34 @@ implementation I = {
         };
     }
 
-    // Value block attempting to return values of different types, should fail
-    function value_block_inconsistent_types(t: T, u: U): T {
-        value t; value u;
+    function test_fun(in: T): T;
+    procedure test_proc(out o: T);
+
+    // Stateful computation when evaluating callable arguments, should fail
+    function stateful_callable_argument(): T = {
+        var t: T;
+        value test_fun(call test_proc(t));
+    }
+
+    // Stateful computation when declaring a variable, should fail
+    function stateful_variable_declaration(): T = {
+        var t: T;
+        var y = call test_proc(t);
+    }
+
+    // Stateful computation within an assertion, should fail
+    function stateful_assertion(): T = {
+        var t: T;
+        assert call test_proc(t);
+    }
+
+    // Access a variable declared in a value block, should fail
+    function access_variable_in_value_block(): T = {
+        var x = {
+            var t: T;
+            call test_proc(t);
+            value t;
+        };
+        x = t;
     }
 };

--- a/tests/outputs/modeCheck.mg.out
+++ b/tests/outputs/modeCheck.mg.out
@@ -7,3 +7,7 @@ tests/inputs/modeCheck.mg:21:46: Mode error: incompatible modes in call to in_ob
 tests/inputs/modeCheck.mg:23:46: Mode error: incompatible modes in call to in_upd: expected upd but got out for argument #1
 
 tests/inputs/modeCheck.mg:32:48: Mode error: incompatible modes in call to in_2_obs: expected obs but got out for argument #1; expected obs but got out for argument #2
+
+tests/inputs/modeCheck.mg:35:38: Mode error: expected expression to have mode obs but it has mode unk
+
+tests/inputs/modeCheck.mg:36:39: Mode error: expected expression to have mode obs but it has mode out

--- a/tests/outputs/stateHandlingTests.mg.out
+++ b/tests/outputs/stateHandlingTests.mg.out
@@ -1,5 +1,13 @@
 tests/inputs/stateHandlingTests.mg:8:5: Type error: expected return type to be Unit in procedure but return value has type T
 
-tests/inputs/stateHandlingTests.mg:14:60: Mode error: incompatible modes in call to _=_: expected out but got unk for argument #1
+tests/inputs/stateHandlingTests.mg:14:60: Type error: value block has conflicting return types (found T, U)
 
-tests/inputs/stateHandlingTests.mg:23:60: Type error: value block has conflicting return types (found T, U)
+tests/inputs/stateHandlingTests.mg:22:13: Mode error: incompatible modes in call to _=_: expected out but got unk for argument #1
+
+tests/inputs/stateHandlingTests.mg:33:29: Mode error: incompatible modes in call to test_proc: expected out but got unk for argument #1
+
+tests/inputs/stateHandlingTests.mg:39:22: Mode error: incompatible modes in call to test_proc: expected out but got unk for argument #1
+
+tests/inputs/stateHandlingTests.mg:45:21: Mode error: incompatible modes in call to test_proc: expected out but got unk for argument #1
+
+tests/inputs/stateHandlingTests.mg:55:13: Error: variable not in scope: t


### PR DESCRIPTION
This makes sure stateful computations (which do not return a value) and
stateless computations (which return a value) are properly
disambiguated in all settings.

Also addresses some problems related to modes, namely:
* update modes after a procedure call
* fix a bug where unk variables are set to obs when making an
   already immutable scope immutable
* allow passing error location specifically to mode checking
  functions