### PR TITLE
Modify MLet to wrap a variable in order to carry around an additional type annotation

### DIFF
--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -231,7 +231,7 @@ instance Pretty (MExpr' p) where
                ]
         MValue expr' -> "value" <+> p expr'
         -- TODO: modes are for now ignore in MLet
-        MLet _ name mcast mass ->
+        MLet (Ann _ (Var _ name mcast)) mass ->
           let pcast = case mcast of Nothing -> ""; Just cast -> " : " <> p cast
               pass = case mass of Nothing -> ""
                                   Just ass -> " = " <> pNoSemi (_elem ass)

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -331,14 +331,15 @@ letStmt = annot letStmt'
   where
     letStmt' = do
       keyword LetKW
-      isConst <- option False (keyword ObsKW $> True)
-      name <- varName
-      ann <- optional (symbol ":" *> typeName)
+      ~(Ann ann (Var declMode name mty)) <- letVar
       value <- optional (symbol "=" *> expr)
-      let mode | isConst = MObs
-               | isNothing value = MOut
-               | otherwise = MUpd
-      return $ MLet mode name ann value
+      let mode = if isNothing value then MOut else declMode
+      return $ MLet (Ann ann (Var mode name mty)) value
+
+    letVar = do
+      mode <- option MUpd (keyword ObsKW $> MObs)
+      var mode
+
 
 assignStmt :: Parser ParsedExpr
 assignStmt = annot assignStmt'

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -195,7 +195,7 @@ data MExpr' p = MVar (MaybeTypedVar p)
               | MCall Name [MExpr p] (Maybe MType)
               | MBlockExpr MBlockType (NE.NonEmpty (MExpr p))
               | MValue (MExpr p)
-              | MLet MVarMode Name (Maybe MType) (Maybe (MExpr p))
+              | MLet (MaybeTypedVar p) (Maybe (MExpr p))
               | MIf (MExpr p) (MExpr p) (MExpr p)
               | MAssert (MExpr p)
               | MSkip


### PR DESCRIPTION
Previously, `MLet` carried around the mode, name, and type of the variable.
This PR replaces this with a `MaybeTypedVar`, which allows an additional
useful type annotation in the AST during type checking.