### PR TITLE
Flesh out required and concrete types handling.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ lint:
 	hlint src
 
 test-targets = declScopeTests \
+		externals \
 		modeTests \
 		parsingTests \
 	       	stateHandlingTests \

--- a/src/lib/Make.hs
+++ b/src/lib/Make.hs
@@ -108,17 +108,17 @@ importLocal
   -> TCTopLevelDecl
   -> [TCTopLevelDecl]
 importLocal name acc decl = case decl of
-  MNamedRenamingDecl (Ann (LocalDecl src) node) ->
-    MNamedRenamingDecl (Ann (mkImportedDecl src node) node):acc
-  MModuleDecl (Ann (LocalDecl src) node) ->
-    MModuleDecl (Ann (mkImportedDecl src node) node):acc
-  MSatisfactionDecl (Ann (LocalDecl src) node) ->
-    MSatisfactionDecl (Ann (mkImportedDecl src node) node):acc
+  MNamedRenamingDecl (Ann (LocalDecl dty src) node) ->
+    MNamedRenamingDecl (Ann (mkImportedDecl dty src node) node):acc
+  MModuleDecl (Ann (LocalDecl dty src) node) ->
+    MModuleDecl (Ann (mkImportedDecl dty src node) node):acc
+  MSatisfactionDecl (Ann (LocalDecl dty src) node) ->
+    MSatisfactionDecl (Ann (mkImportedDecl dty src node) node):acc
   -- We do not import non-local decls from other packages.
   _ -> acc -- Ann (src, ImportedDecl name (nodeName modul)) modul:acc
   where
-    mkImportedDecl src node =
-      ImportedDecl (FullyQualifiedName (Just name) (nodeName node)) src
+    mkImportedDecl dty src node =
+      ImportedDecl (FullyQualifiedName (Just name) (nodeName node)) dty src
 
 
 -- TODO: optimize as needed, could be more elegant.
@@ -141,7 +141,7 @@ upsweepRenamings = foldMAccumErrors go
       expandedBlock <-
         expandRenamingBlock (M.map getNamedRenamings env) renamingBlock
         -- TODO: expand named renamings
-      let tcNamedRenaming = Ann (LocalDecl src)
+      let tcNamedRenaming = Ann (LocalDecl ConcreteDecl src)
                                 (MNamedRenaming name expandedBlock)
       return $ M.insertWith (<>) name [MNamedRenamingDecl tcNamedRenaming]
                             env

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -182,7 +182,13 @@ instance Pretty MModuleType where
     Concept -> "concept"
     Implementation -> "implementation"
     Program -> "program"
-    External -> "external"
+    External backend fqn -> "external" <+> p backend <+> p fqn
+
+instance Pretty Backend where
+  pretty backend = case backend of
+    Cxx -> "C++"
+    JavaScript -> "JavaScript"
+    Python -> "Python"
 
 instance Pretty (MDecl PhCheck) where
   pretty decl = case decl of
@@ -190,7 +196,8 @@ instance Pretty (MDecl PhCheck) where
     CallableDecl cdecl -> pretty cdecl
 
 instance Pretty (TypeDecl' p) where
-  pretty (Type typ) = "type" <+> p typ <> ";"
+  pretty (Type typ isRequired) = (if isRequired then "require" else "") <>
+    "type" <+> p typ <> ";"
 
 instance Pretty (CallableDecl' p) where
   pretty (Callable callableType name args ret mguard cbody) =

--- a/tests/inputs/externals.mg
+++ b/tests/inputs/externals.mg
@@ -1,0 +1,32 @@
+package tests.inputs.externals;
+
+// TODO: implement external handling, and add tests.
+implementation ICxx = external C++ some.cxx.file {
+    type T;
+}
+
+implementation IJS = external JavaScript some.js.file {
+    type T;
+}
+
+implementation IPy = external Python some.py.file {
+    type T;
+}
+
+// should succeed
+implementation UnifySameConcreteType = {
+    use ICxx;
+    use ICxx;
+}
+
+// should fail
+implementation UnifyDifferentConcreteType = {
+    use ICxx;
+    use IJS;
+}
+
+// should succeed
+implementation UnifyRequiredAndConcreteType = {
+    use ICxx;
+    type T;
+}

--- a/tests/outputs/externals.mg.out
+++ b/tests/outputs/externals.mg.out
@@ -1,0 +1,1 @@
+tests/inputs/externals.mg:25:5: Declaration error: attempting to define concrete type T but a concrete type with name T is already in scope


### PR DESCRIPTION
The implementation given here is rather brittle, and should be improved
once a proper core language for the Magnolia compiler is created.

Handling required types is blocking for code generation however, hence
why this initial implementation is provided.

This commit also fixes the source location for errors related to 'uses'.