### PR TITLE
Improve the internal handling of requirements and implementations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,10 @@ lint:
 	hlint src
 
 test-targets = declScopeTests \
-		externals \
+		externalTests \
 		modeTests \
 		parsingTests \
+		requirementTests \
 	       	stateHandlingTests \
 		stmtTests
 

--- a/src/lib/Make.hs
+++ b/src/lib/Make.hs
@@ -108,17 +108,17 @@ importLocal
   -> TcTopLevelDecl
   -> [TcTopLevelDecl]
 importLocal name acc decl = case decl of
-  MNamedRenamingDecl (Ann (LocalDecl dty src) node) ->
-    MNamedRenamingDecl (Ann (mkImportedDecl dty src node) node):acc
-  MModuleDecl (Ann (LocalDecl dty src) node) ->
-    MModuleDecl (Ann (mkImportedDecl dty src node) node):acc
-  MSatisfactionDecl (Ann (LocalDecl dty src) node) ->
-    MSatisfactionDecl (Ann (mkImportedDecl dty src node) node):acc
+  MNamedRenamingDecl (Ann (LocalDecl src) node) ->
+    MNamedRenamingDecl (Ann (mkImportedDecl src node) node):acc
+  MModuleDecl (Ann (LocalDecl src) node) ->
+    MModuleDecl (Ann (mkImportedDecl src node) node):acc
+  MSatisfactionDecl (Ann (LocalDecl src) node) ->
+    MSatisfactionDecl (Ann (mkImportedDecl src node) node):acc
   -- We do not import non-local decls from other packages.
   _ -> acc -- Ann (src, ImportedDecl name (nodeName modul)) modul:acc
   where
-    mkImportedDecl dty src node =
-      ImportedDecl (FullyQualifiedName (Just name) (nodeName node)) dty src
+    mkImportedDecl src node =
+      ImportedDecl (FullyQualifiedName (Just name) (nodeName node)) src
 
 
 -- TODO: optimize as needed, could be more elegant.
@@ -141,7 +141,7 @@ upsweepRenamings = foldMAccumErrors go
       expandedBlock <-
         expandRenamingBlock (M.map getNamedRenamings env) renamingBlock
         -- TODO: expand named renamings
-      let tcNamedRenaming = Ann (LocalDecl ConcreteDecl src)
+      let tcNamedRenaming = Ann (LocalDecl src)
                                 (MNamedRenaming name expandedBlock)
       return $ M.insertWith (<>) name [MNamedRenamingDecl tcNamedRenaming]
                             env

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -546,6 +546,6 @@ withSrc p = do
   start <- mkSrcPos <$> getSourcePos
   element <- p
   end <- mkSrcPos <$> getSourcePos
-  return $ WithSrc (Just (start, end)) element
+  return $ WithSrc (SrcCtx $ Just (start, end)) element
   where
     mkSrcPos s = (sourceName s, unPos $ sourceLine s, unPos $ sourceColumn s)

--- a/tests/inputs/declScopeTests.mg
+++ b/tests/inputs/declScopeTests.mg
@@ -55,19 +55,27 @@ implementation I = {
     axiom axiomBody() = {};
 };
 
+implementation IExt = external C++ Ext {
+    type U;
+}
+
 program P = {
     /* A Magnolia program can contain anything, except for axioms.
      * However, callables *MUST* eventually be given a body.
      */
 
     // Valid declarations
-    type T;
+    type T; // errors without external definition, but is valid in itself
     function funProto(): T; // errors without body, but is valid in itself
     procedure procProto();  // errors without body, but is valid in itself
     predicate predProto();  // errors without body, but is valid in itself
     function funBody(): T = funProto();
     procedure procBody() = call procProto();
     predicate predBody() = predProto();
+    // Requiring a type is fine, as long as we provide an external
+    // implementation (here, it comes from IExt).
+    require type U;
+    use IExt;
 
     // Invalid declarations
     axiom axiomBody() = {}; // TODO: unimplemented error should be removed

--- a/tests/inputs/externalTests.mg
+++ b/tests/inputs/externalTests.mg
@@ -1,4 +1,4 @@
-package tests.inputs.externals;
+package tests.inputs.externalTests;
 
 // TODO: implement external handling, and add tests.
 implementation ICxx = external C++ some.cxx.file {

--- a/tests/inputs/requirementTests.mg
+++ b/tests/inputs/requirementTests.mg
@@ -1,0 +1,32 @@
+package tests.inputs.requirementTests;
+
+signature Req = {
+    type T;
+    function f(): T;
+}
+
+implementation IExtReq1 = external C++ ExtReq1 {
+    type T;
+    function f(): T;
+}
+
+implementation IExtReq2 = external C++ ExtReq2 {
+    type T;
+    function f(): T;
+}
+
+implementation IExtReq3 = external C++ ExtReq3 {
+    type T;
+    require type T; // should succeed
+    type T; // should fail
+}
+
+implementation MergingImpls = {
+    use IExtReq1;
+    use IExtReq2; // should fail
+    use IExtReq1; // should succeed
+    require type T; // should succeed
+    type T; // should succeed
+    function f(): T; // should succeed
+    function f(): T; // should succeed
+}

--- a/tests/outputs/declScopeTests.mg.out
+++ b/tests/outputs/declScopeTests.mg.out
@@ -14,12 +14,18 @@ tests/inputs/declScopeTests.mg:38:5: Declaration error: predicate can not have a
 
 tests/inputs/declScopeTests.mg:55:5: Declaration context error: axioms can only be declared in concepts
 
-tests/inputs/declScopeTests.mg:65:5: Declaration error: function funProto () : T; was left unimplemented in program
+tests/inputs/declScopeTests.mg:62:13: Declaration error: T was left unimplemented in program P
 
-tests/inputs/declScopeTests.mg:66:5: Declaration error: procedure procProto (); was left unimplemented in program
+tests/inputs/declScopeTests.mg:62:13: Declaration error: _==_ was left unimplemented in program P
 
-tests/inputs/declScopeTests.mg:67:5: Declaration error: predicate predProto (); was left unimplemented in program
+tests/inputs/declScopeTests.mg:62:13: Declaration error: _=_ was left unimplemented in program P
 
-tests/inputs/declScopeTests.mg:73:5: Declaration error: axiom axiomBody (); was left unimplemented in program
+tests/inputs/declScopeTests.mg:62:13: Declaration error: axiomBody was left unimplemented in program P
 
-tests/inputs/declScopeTests.mg:73:5: Declaration context error: axioms can only be declared in concepts
+tests/inputs/declScopeTests.mg:62:13: Declaration error: funProto was left unimplemented in program P
+
+tests/inputs/declScopeTests.mg:62:13: Declaration error: predProto was left unimplemented in program P
+
+tests/inputs/declScopeTests.mg:62:13: Declaration error: procProto was left unimplemented in program P
+
+tests/inputs/declScopeTests.mg:81:5: Declaration context error: axioms can only be declared in concepts

--- a/tests/outputs/externalTests.mg.out
+++ b/tests/outputs/externalTests.mg.out
@@ -1,0 +1,5 @@
+tests/inputs/externalTests.mg:25:5: Declaration error: got conflicting implementations for function _==_(e1 : T, e2 : T) : Predicate at tests/inputs/externalTests.mg:5:5 and tests/inputs/externalTests.mg:9:5
+
+tests/inputs/externalTests.mg:25:5: Declaration error: got conflicting implementations for procedure _=_(out var : T, obs expr : T) at tests/inputs/externalTests.mg:5:5 and tests/inputs/externalTests.mg:9:5
+
+tests/inputs/externalTests.mg:25:5: Declaration error: got conflicting implementations for type T at tests/inputs/externalTests.mg:5:5 and tests/inputs/externalTests.mg:9:5

--- a/tests/outputs/externals.mg.out
+++ b/tests/outputs/externals.mg.out
@@ -1,1 +1,0 @@
-tests/inputs/externals.mg:25:5: Declaration error: attempting to define concrete type T but a concrete type with name T is already in scope

--- a/tests/outputs/modeTests.mg.out
+++ b/tests/outputs/modeTests.mg.out
@@ -1,6 +1,6 @@
-tests/inputs/modeTests.mg:7:5: Mode error: attempting to overload modes in definition of procedure overload_one_param: have modes (out), but a declaration with modes (obs) is already in scope
+tests/inputs/modeTests.mg:8:5: Mode error: attempting to overload modes in definition of procedure overload_one_param: have modes (obs), but a declaration with modes (out) is already in scope
 
-tests/inputs/modeTests.mg:10:5: Mode error: attempting to overload modes in definition of procedure overload_two_param: have modes (obs, upd), but a declaration with modes (obs, out) is already in scope
+tests/inputs/modeTests.mg:11:5: Mode error: attempting to overload modes in definition of procedure overload_two_param: have modes (obs, out), but a declaration with modes (obs, upd) is already in scope
 
 tests/inputs/modeTests.mg:19:46: Mode error: incompatible modes in call to in_out: expected out but got obs for argument #1
 

--- a/tests/outputs/parsingTests.mg.out
+++ b/tests/outputs/parsingTests.mg.out
@@ -1,4 +1,4 @@
-<no context>: Parse error: tests/inputs/parsingTests.mg:2:1:
+<unknown location>: Parse error: tests/inputs/parsingTests.mg:2:1:
   |
 2 | <empty line>
   | ^

--- a/tests/outputs/requirementTests.mg.out
+++ b/tests/outputs/requirementTests.mg.out
@@ -1,0 +1,9 @@
+tests/inputs/requirementTests.mg:21:5: Declaration error: got conflicting implementations for type T at tests/inputs/requirementTests.mg:19:5 and tests/inputs/requirementTests.mg:21:5
+
+tests/inputs/requirementTests.mg:26:5: Declaration error: got conflicting implementations for function _==_(e1 : T, e2 : T) : Predicate at tests/inputs/requirementTests.mg:9:5 and tests/inputs/requirementTests.mg:14:5
+
+tests/inputs/requirementTests.mg:26:5: Declaration error: got conflicting implementations for function f() : T at tests/inputs/requirementTests.mg:10:5 and tests/inputs/requirementTests.mg:15:5
+
+tests/inputs/requirementTests.mg:26:5: Declaration error: got conflicting implementations for procedure _=_(out var : T, obs expr : T) at tests/inputs/requirementTests.mg:9:5 and tests/inputs/requirementTests.mg:14:5
+
+tests/inputs/requirementTests.mg:26:5: Declaration error: got conflicting implementations for type T at tests/inputs/requirementTests.mg:9:5 and tests/inputs/requirementTests.mg:14:5


### PR DESCRIPTION
The distinction between concrete declarations (e.g. external types,
callables with bodies) and abstract declarations (e.g. required types,
function prototypes) was not clearly enforced within the compiler;
before, we allowed our scope to contain several declarations for a given
callable, namely one for the prototype, and one for the implementation.
This required some careful manipulations of the scope when registering
new types/prototypes, which was brittle and undesirable.

This commit modifies the type of annotations of module-level
declarations such that they now carry around a (non-empty) list of
abstract declaration origins, as well as maybe one concrete declaration
origin, such that:
    * each concrete declaration produces both a concrete and an abstract
      declaration origin;
    * each abstract declaration produces only an abstract declaration
      origin;
    * two declarations can be merged if at least one of them is abstract
      OR if they correspond to the same concrete declaration (e.g. if
      a function is imported through different paths with the same name,
      for instance).

With this, we can now carry around one unique node in scope
corresponding to both the abstract & concrete version of a given
declaration. Any duplicate should now be a compiler error.

We perform some hacks to deal with the "hackyPrelude", which should not
be looked too hard into.