### PR TITLE
More descriptive error message in mergeGuards

### DIFF
--- a/src/lib/Check.hs
+++ b/src/lib/Check.hs
@@ -661,8 +661,9 @@ insertAndMergeDecl env decl = do
         -- We consider two guards as equivalent only if they are
         -- syntactically equal.
         if guard1 == guard2 then return $ Just guard1
-        else throwLocatedE NotImplementedErr errorLoc
-          "merging of two callables with different guards"
+        else throwLocatedE NotImplementedErr errorLoc $
+          "merging of two callables " <> pshow name <>
+          " with different guards " <> pshow guard1 <> " and " <> pshow guard2
 
     -- When attempting to merge two existing declarations, we have 3 distinct
     -- cases:

--- a/tests/inputs/requirementTests.mg
+++ b/tests/inputs/requirementTests.mg
@@ -30,3 +30,12 @@ implementation MergingImpls = {
     function f(): T; // should succeed
     function f(): T; // should succeed
 }
+
+implementation MergingGuards = {
+    type T;
+    predicate g_1();
+    predicate g_2();
+
+    function f(): T guard g_1(); // should succeed
+    function f(): T guard g_2(); // should succeed TODO: unimplemented, 05.07.21
+}

--- a/tests/outputs/requirementTests.mg.out
+++ b/tests/outputs/requirementTests.mg.out
@@ -7,3 +7,5 @@ tests/inputs/requirementTests.mg:26:5: Declaration error: got conflicting implem
 tests/inputs/requirementTests.mg:26:5: Declaration error: got conflicting implementations for procedure _=_(out var : T, obs expr : T) at tests/inputs/requirementTests.mg:9:5 and tests/inputs/requirementTests.mg:14:5
 
 tests/inputs/requirementTests.mg:26:5: Declaration error: got conflicting implementations for type T at tests/inputs/requirementTests.mg:9:5 and tests/inputs/requirementTests.mg:14:5
+
+tests/inputs/requirementTests.mg:40:5: Not implemented: merging of two callables f with different guards g_2(); and g_1();


### PR DESCRIPTION
Minor improvement in error message for `mergeGuards`. This will probably see more improvements once it is fully implemented.