### PR TITLE
Implements partial and total renamings.

### DIFF
--- a/src/lib/Magnolia/PPrint.hs
+++ b/src/lib/Magnolia/PPrint.hs
@@ -151,8 +151,11 @@ instance Pretty (MModuleDep' PhCheck) where
                  else "") <> ";"
 
 instance Pretty (MRenamingBlock' PhCheck) where
-  pretty (MRenamingBlock renamings) =
-    brackets $ hsep (punctuate comma (map p renamings))
+  pretty (MRenamingBlock renamingBlockTy renamings) =
+    let content = hsep (punctuate comma (map p renamings))
+    in case renamingBlockTy of
+      PartialRenamingBlock -> "[[" <> content <> "]]"
+      TotalRenamingBlock -> brackets content
 
 instance Pretty (MRenaming' PhCheck) where
   pretty renaming = case renaming of

--- a/src/lib/Magnolia/Parser.hs
+++ b/src/lib/Magnolia/Parser.hs
@@ -292,8 +292,13 @@ moduleDependency = annot $ do
   return $ MModuleDep name renamings castToSignature
 
 renamingBlock :: Parser ParsedRenamingBlock
-renamingBlock = annot $
-  MRenamingBlock <$> brackets (renaming `sepBy` symbol ",")
+renamingBlock = annot $ do
+  (renamings, renamingBlockType) <-
+        ((,PartialRenamingBlock) <$>
+            doubleBrackets (renaming `sepBy` symbol ","))
+    <|> ((,TotalRenamingBlock) <$>
+            brackets (renaming `sepBy` symbol ","))
+  return $ MRenamingBlock renamingBlockType renamings
 
 renaming :: Parser ParsedRenaming
 renaming = try inlineRenaming
@@ -364,6 +369,9 @@ braces = between (symbol "{") (symbol "}")
 
 brackets :: Parser a -> Parser a
 brackets = between (symbol "[") (symbol "]")
+
+doubleBrackets :: Parser a -> Parser a
+doubleBrackets = between (symbol "[[") (symbol "]]")
 
 parens :: Parser a -> Parser a
 parens = between (symbol "(") (symbol ")")

--- a/src/lib/Magnolia/Syntax.hs
+++ b/src/lib/Magnolia/Syntax.hs
@@ -47,6 +47,7 @@ module Magnolia.Syntax (
   , MRenaming' (..)
   , MRenamingBlock
   , MRenamingBlock' (..)
+  , MRenamingBlockType (..)
   , MSatisfaction
   , MSatisfaction' (..)
   , MTopLevelDecl (..)
@@ -275,8 +276,16 @@ data MModuleDep' p = MModuleDep { _depName :: FullyQualifiedName
                                 , _depCastToSig :: Bool
                                 }
 
+-- | There are two types of renaming blocks: partial renaming blocks, and
+-- total renaming blocks. A partial renaming block is a renaming block that
+-- may contain source names that do not exist in the module expression it is
+-- applied to. In contrast, a total renaming block expects that all its source
+-- names exist in the module expression it is applied to.
 type MRenamingBlock p = Ann p MRenamingBlock'
-newtype MRenamingBlock' p = MRenamingBlock [MRenaming p]
+data MRenamingBlock' p = MRenamingBlock MRenamingBlockType [MRenaming p]
+
+data MRenamingBlockType = PartialRenamingBlock | TotalRenamingBlock
+                          deriving (Eq, Show)
 
 type MRenaming p = Ann p MRenaming'
 data MRenaming' p = InlineRenaming InlineRenaming
@@ -622,7 +631,7 @@ instance HasDependencies (MNamedRenaming' PhParse) where
     dependencies renamingBlock
 
 instance HasDependencies (MRenamingBlock' PhParse) where
-  dependencies (MRenamingBlock renamings) =
+  dependencies (MRenamingBlock _ renamings) =
     foldr (\(Ann _ r) acc -> case r of RefRenaming n -> n:acc ; _ -> acc) []
           renamings
 

--- a/src/lib/Magnolia/Util.hs
+++ b/src/lib/Magnolia/Util.hs
@@ -267,7 +267,7 @@ checkNoCycle (G.AcyclicSCC vertex) = return vertex
 -- === renamings manipulation ===
 
 renamingBlockToInlineRenamings :: TcRenamingBlock -> [InlineRenaming]
-renamingBlockToInlineRenamings (Ann _ (MRenamingBlock renamings)) =
+renamingBlockToInlineRenamings (Ann _ (MRenamingBlock _ renamings)) =
     map mkInlineRenaming renamings
   where mkInlineRenaming (Ann _ r) = case r of InlineRenaming ir -> ir
                                                RefRenaming v -> absurd v

--- a/tests/check/inputs/renamingTests.mg
+++ b/tests/check/inputs/renamingTests.mg
@@ -37,6 +37,10 @@ implementation SwapTypesMultipleSteps = {
     function _t1(): T1 = __t1(); // should succeed
 }
 
+implementation NonExistentSourcesInTotalAndPartialRenaming = {
+    use ToRename[Z => Z]; // should fail
+    use ToRename[[Z => Z]]; // should succeed
+}
 
 implementation ToRenameExt = external C++ ToRenameExtCxx {
     type T;

--- a/tests/check/outputs/renamingTests.mg.out
+++ b/tests/check/outputs/renamingTests.mg.out
@@ -1,5 +1,7 @@
-tests/check/inputs/renamingTests.mg:50:5: Declaration error in tests.check.inputs.renamingTests.RenamingOverload: got conflicting implementations for function _f(_t : _T) : _T at tests/check/inputs/renamingTests.mg:43:5 and tests/check/inputs/renamingTests.mg:50:5
+tests/check/inputs/renamingTests.mg:41:17: Error in tests.check.inputs.renamingTests.NonExistentSourcesInTotalAndPartialRenaming: total renaming block contains unknown sources: Z
 
-tests/check/inputs/renamingTests.mg:60:5: Error: type not in scope in tests.check.inputs.renamingTests.CheckRenamedModuleExprDef: T
+tests/check/inputs/renamingTests.mg:54:5: Declaration error in tests.check.inputs.renamingTests.RenamingOverload: got conflicting implementations for function _f(_t : _T) : _T at tests/check/inputs/renamingTests.mg:47:5 and tests/check/inputs/renamingTests.mg:54:5
 
-tests/check/inputs/renamingTests.mg:68:5: Error: type not in scope in tests.check.inputs.renamingTests.CheckRenamedModuleExprRef: T1
+tests/check/inputs/renamingTests.mg:64:5: Error: type not in scope in tests.check.inputs.renamingTests.CheckRenamedModuleExprDef: T
+
+tests/check/inputs/renamingTests.mg:72:5: Error: type not in scope in tests.check.inputs.renamingTests.CheckRenamedModuleExprRef: T1


### PR DESCRIPTION
Two types of renamings can now be applied. Assuming a module A, one can
write `A[Z => Z]` or `A[[Z => Z]]` to apply respectively a total and a
partial renaming block to A.

The expectations are that total renaming blocks expect source names in
the block to correspond to the name of at least one declaration in `A`,
while partial renaming blocks have no such expectations, and therefore
allow renamings with non-existent sources.