### PR TITLE
Implement handling of function requirements in C++ code generation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ check-output-%: tests/$(pass)/inputs/%.mg tests/$(pass)/outputs/%.mg.out build
 update-output-%: tests/$(pass)/inputs/%.mg build
 	$(mgn) test --pass $(pass) --output-directory=$(tests-out-dir) $< > tests/$(pass)/outputs/$(notdir $<).out
 
-example-names = fizzbuzz
+example-names = fizzbuzz \
+                while_loop
 
 build-examples: $(example-names:%=build-example-%)
 

--- a/examples/containers/Makefile
+++ b/examples/containers/Makefile
@@ -1,0 +1,24 @@
+TARGET := $(shell basename `pwd`).bin
+
+.PHONY: all clean setup
+
+BIN_DIR := bin
+CPP_SOURCE_DIR := cpp-src
+CPP_SOURCES := $(shell find $(CPP_SOURCE_DIR) -name "*.cpp")
+
+CC := clang++
+CCFLAGS := -g -std=c++20 -I$(CPP_SOURCE_DIR)
+
+MKDIR := @mkdir
+RM := @rm
+
+all: setup
+	clang++ $(CCFLAGS) $(CPP_SOURCES) -o $(BIN_DIR)/$(TARGET)
+	@echo $(TARGET)
+	@echo $(CPP_SOURCES)
+
+setup:
+	$(MKDIR) -p $(BIN_DIR)
+
+clean:
+	$(RM) -r $(BIN_DIR)

--- a/examples/containers/cpp-src/base.hpp
+++ b/examples/containers/cpp-src/base.hpp
@@ -1,0 +1,23 @@
+#include <utility>
+
+template <typename _A, typename _B>
+struct pair {
+    typedef _A A;
+    typedef _B B;
+    typedef std::pair<pair::A, pair::B> Pair;
+
+    inline pair::Pair make_pair(const pair::A &a, const pair::B &b) {
+        return std::make_pair(a, b);
+    }
+    inline pair::A first(const pair::Pair &pair) {
+        return pair.first;
+    }
+    inline pair::B second(const pair::Pair &pair) {
+        return pair.second;
+    }
+};
+
+struct types {
+    typedef short Int16;
+    typedef int Int32;
+};

--- a/examples/containers/cpp-src/gen/examples/containers/mg-src/containers.cpp
+++ b/examples/containers/cpp-src/gen/examples/containers/mg-src/containers.cpp
@@ -1,0 +1,36 @@
+#include "gen/examples/containers/mg-src/containers.hpp"
+
+
+namespace examples {
+namespace containers {
+namespace mg_src {
+namespace containers {
+    types NestedPairProgram::__types;
+    NestedPairProgram::_first NestedPairProgram::first;
+    NestedPairProgram::_make_pair NestedPairProgram::make_pair;
+    NestedPairProgram::_second NestedPairProgram::second;
+    pair<NestedPairProgram::InnerPair, NestedPairProgram::InnerPair> NestedPairProgram::__pair;
+    pair<NestedPairProgram::Int16, NestedPairProgram::Int32> NestedPairProgram::__pair0;
+    NestedPairProgram::Int16 NestedPairProgram::_first::operator()(const NestedPairProgram::InnerPair& t) {
+        return __pair0.first(t);
+    };
+    NestedPairProgram::InnerPair NestedPairProgram::_first::operator()(const NestedPairProgram::OuterPair& t) {
+        return __pair.first(t);
+    };
+    NestedPairProgram::OuterPair NestedPairProgram::_make_pair::operator()(const NestedPairProgram::InnerPair& a, const NestedPairProgram::InnerPair& b) {
+        return __pair.make_pair(a, b);
+    };
+    NestedPairProgram::InnerPair NestedPairProgram::_make_pair::operator()(const NestedPairProgram::Int16& a, const NestedPairProgram::Int32& b) {
+        return __pair0.make_pair(a, b);
+    };
+    NestedPairProgram::Int32 NestedPairProgram::_second::operator()(const NestedPairProgram::InnerPair& t) {
+        return __pair0.second(t);
+    };
+    NestedPairProgram::InnerPair NestedPairProgram::_second::operator()(const NestedPairProgram::OuterPair& t) {
+        return __pair.second(t);
+    };
+
+} // examples
+} // containers
+} // mg_src
+} // containers

--- a/examples/containers/cpp-src/gen/examples/containers/mg-src/containers.hpp
+++ b/examples/containers/cpp-src/gen/examples/containers/mg-src/containers.hpp
@@ -1,0 +1,45 @@
+#include "base.hpp"
+#include <cassert>
+
+
+namespace examples {
+namespace containers {
+namespace mg_src {
+namespace containers {
+struct NestedPairProgram {
+    struct _first;
+    struct _make_pair;
+    struct _second;
+    typedef types::Int32 Int32;
+    typedef types::Int16 Int16;
+    typedef pair<Int16, Int32>::Pair InnerPair;
+    typedef pair<InnerPair, InnerPair>::Pair OuterPair;
+    struct _first {
+        NestedPairProgram::Int16 operator()(const NestedPairProgram::InnerPair& t);
+        NestedPairProgram::InnerPair operator()(const NestedPairProgram::OuterPair& t);
+    };
+
+    struct _make_pair {
+        NestedPairProgram::OuterPair operator()(const NestedPairProgram::InnerPair& a, const NestedPairProgram::InnerPair& b);
+        NestedPairProgram::InnerPair operator()(const NestedPairProgram::Int16& a, const NestedPairProgram::Int32& b);
+    };
+
+    struct _second {
+        NestedPairProgram::Int32 operator()(const NestedPairProgram::InnerPair& t);
+        NestedPairProgram::InnerPair operator()(const NestedPairProgram::OuterPair& t);
+    };
+
+private:
+    static types __types;
+public:
+    static NestedPairProgram::_first first;
+    static NestedPairProgram::_make_pair make_pair;
+    static NestedPairProgram::_second second;
+private:
+    static pair<NestedPairProgram::InnerPair, NestedPairProgram::InnerPair> __pair;
+    static pair<NestedPairProgram::Int16, NestedPairProgram::Int32> __pair0;
+};
+} // examples
+} // containers
+} // mg_src
+} // containers

--- a/examples/containers/cpp-src/main.cpp
+++ b/examples/containers/cpp-src/main.cpp
@@ -1,0 +1,38 @@
+#include "gen/examples/containers/mg-src/containers.hpp"
+#include <iostream>
+
+using examples::containers::mg_src::containers::NestedPairProgram;
+
+int main(int argc, char **argv) {
+    --argc;
+    if (argc < 4) {
+        std::cerr << "Usage: " << argv[0] << " <int16> <int32> <int16> <int32>"
+                  << std::endl;
+        return 1;
+    }
+
+    NestedPairProgram P;
+    NestedPairProgram::Int16 e00, e10;
+    NestedPairProgram::Int32 e01, e11;
+
+    e00 = atoi(argv[1]);
+    e01 = atoi(argv[2]);
+    e10 = atoi(argv[3]);
+    e11 = atoi(argv[4]);
+    
+    auto outer_pair = P.make_pair(P.make_pair(e00, e01),
+                                  P.make_pair(e10, e11));
+
+    std::cout << "Elements are: " << std::endl;
+    std::cout << "("
+              << P.first(P.first(outer_pair))
+              << ", "
+              << P.second(P.first(outer_pair))
+              << ")," << std::endl
+              << "("
+              << P.first(P.second(outer_pair))
+              << ", "
+              << P.second(P.second(outer_pair))
+              << ")" << std::endl;
+    return 0;
+}

--- a/examples/containers/mg-src/containers.mg
+++ b/examples/containers/mg-src/containers.mg
@@ -1,0 +1,28 @@
+package examples.containers.mg-src.containers;
+
+implementation Pair = external C++ base.pair {
+    require type A;
+    require type B;
+    type Pair;
+
+    function make_pair(a: A, b: B): Pair;
+    function first(t: Pair): A;
+    function second(t: Pair): B;
+}
+
+implementation Types = external C++ base.types {
+    type Int16;
+    type Int32;
+}
+
+program NestedPairProgram = {
+    use Types;
+    use Pair[ Pair => InnerPair
+            , A => Int16
+            , B => Int32
+            ];
+    use Pair[ Pair => OuterPair
+            , A => InnerPair
+            , B => InnerPair
+            ];
+}

--- a/examples/fizzbuzz/cpp-src/gen/examples/fizzbuzz/mg-src/fizzbuzz.cpp
+++ b/examples/fizzbuzz/cpp-src/gen/examples/fizzbuzz/mg-src/fizzbuzz.cpp
@@ -5,10 +5,21 @@ namespace examples {
 namespace fizzbuzz {
 namespace mg_src {
 namespace fizzbuzz {
-    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::buzz() {
+    basic_types MyFizzBuzzProgram::__basic_types;
+    MyFizzBuzzProgram::_buzz MyFizzBuzzProgram::buzz;
+    MyFizzBuzzProgram::_doFizzBuzz MyFizzBuzzProgram::doFizzBuzz;
+    MyFizzBuzzProgram::_five MyFizzBuzzProgram::five;
+    MyFizzBuzzProgram::_fizz MyFizzBuzzProgram::fizz;
+    MyFizzBuzzProgram::_fizzbuzz MyFizzBuzzProgram::fizzbuzz;
+    MyFizzBuzzProgram::_modulo MyFizzBuzzProgram::modulo;
+    MyFizzBuzzProgram::_nope MyFizzBuzzProgram::nope;
+    MyFizzBuzzProgram::_three MyFizzBuzzProgram::three;
+    MyFizzBuzzProgram::_zero MyFizzBuzzProgram::zero;
+    fizzbuzz_ops<MyFizzBuzzProgram::Int32> MyFizzBuzzProgram::__fizzbuzz_ops;
+    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::_buzz::operator()() {
         return __fizzbuzz_ops.buzz();
     };
-    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::doFizzBuzz(const MyFizzBuzzProgram::Int32& i) {
+    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::_doFizzBuzz::operator()(const MyFizzBuzzProgram::Int32& i) {
         if (((MyFizzBuzzProgram::modulo(i, MyFizzBuzzProgram::three())) == (MyFizzBuzzProgram::zero())) && ((MyFizzBuzzProgram::modulo(i, MyFizzBuzzProgram::five())) == (MyFizzBuzzProgram::zero())))
             return MyFizzBuzzProgram::fizzbuzz();
         else
@@ -20,27 +31,28 @@ namespace fizzbuzz {
                 else
                     return MyFizzBuzzProgram::nope();
     };
-    MyFizzBuzzProgram::Int32 MyFizzBuzzProgram::five() {
+    MyFizzBuzzProgram::Int32 MyFizzBuzzProgram::_five::operator()() {
         return __fizzbuzz_ops.five();
     };
-    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::fizz() {
+    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::_fizz::operator()() {
         return __fizzbuzz_ops.fizz();
     };
-    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::fizzbuzz() {
+    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::_fizzbuzz::operator()() {
         return __fizzbuzz_ops.fizzbuzz();
     };
-    MyFizzBuzzProgram::Int32 MyFizzBuzzProgram::modulo(const MyFizzBuzzProgram::Int32& a, const MyFizzBuzzProgram::Int32& modulus) {
+    MyFizzBuzzProgram::Int32 MyFizzBuzzProgram::_modulo::operator()(const MyFizzBuzzProgram::Int32& a, const MyFizzBuzzProgram::Int32& modulus) {
         return __fizzbuzz_ops.modulo(a, modulus);
     };
-    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::nope() {
+    MyFizzBuzzProgram::FizzBuzz MyFizzBuzzProgram::_nope::operator()() {
         return __fizzbuzz_ops.nope();
     };
-    MyFizzBuzzProgram::Int32 MyFizzBuzzProgram::three() {
+    MyFizzBuzzProgram::Int32 MyFizzBuzzProgram::_three::operator()() {
         return __fizzbuzz_ops.three();
     };
-    MyFizzBuzzProgram::Int32 MyFizzBuzzProgram::zero() {
+    MyFizzBuzzProgram::Int32 MyFizzBuzzProgram::_zero::operator()() {
         return __fizzbuzz_ops.zero();
     };
+
 } // examples
 } // fizzbuzz
 } // mg_src

--- a/examples/fizzbuzz/cpp-src/gen/examples/fizzbuzz/mg-src/fizzbuzz.hpp
+++ b/examples/fizzbuzz/cpp-src/gen/examples/fizzbuzz/mg-src/fizzbuzz.hpp
@@ -12,19 +12,65 @@ private:
 public:
     typedef basic_types::Int32 Int32;
     typedef fizzbuzz_ops<dummy_struct>::FizzBuzz FizzBuzz;
-    MyFizzBuzzProgram::FizzBuzz buzz();
-    MyFizzBuzzProgram::FizzBuzz doFizzBuzz(const MyFizzBuzzProgram::Int32& i);
-    MyFizzBuzzProgram::Int32 five();
-    MyFizzBuzzProgram::FizzBuzz fizz();
-    MyFizzBuzzProgram::FizzBuzz fizzbuzz();
-    MyFizzBuzzProgram::Int32 modulo(const MyFizzBuzzProgram::Int32& a, const MyFizzBuzzProgram::Int32& modulus);
-    MyFizzBuzzProgram::FizzBuzz nope();
-    MyFizzBuzzProgram::Int32 three();
-    MyFizzBuzzProgram::Int32 zero();
-private:
-    basic_types __basic_types;
-    fizzbuzz_ops<Int32> __fizzbuzz_ops;
+    
+    struct _buzz {
+        MyFizzBuzzProgram::FizzBuzz operator()();
+    };
 
+    
+    struct _doFizzBuzz {
+        MyFizzBuzzProgram::FizzBuzz operator()(const MyFizzBuzzProgram::Int32& i);
+    };
+
+    
+    struct _five {
+        MyFizzBuzzProgram::Int32 operator()();
+    };
+
+    
+    struct _fizz {
+        MyFizzBuzzProgram::FizzBuzz operator()();
+    };
+
+    
+    struct _fizzbuzz {
+        MyFizzBuzzProgram::FizzBuzz operator()();
+    };
+
+    
+    struct _modulo {
+        MyFizzBuzzProgram::Int32 operator()(const MyFizzBuzzProgram::Int32& a, const MyFizzBuzzProgram::Int32& modulus);
+    };
+
+    
+    struct _nope {
+        MyFizzBuzzProgram::FizzBuzz operator()();
+    };
+
+    
+    struct _three {
+        MyFizzBuzzProgram::Int32 operator()();
+    };
+
+    
+    struct _zero {
+        MyFizzBuzzProgram::Int32 operator()();
+    };
+
+private:
+    static basic_types __basic_types;
+public:
+    static MyFizzBuzzProgram::_buzz buzz;
+    static MyFizzBuzzProgram::_doFizzBuzz doFizzBuzz;
+    static MyFizzBuzzProgram::_five five;
+    static MyFizzBuzzProgram::_fizz fizz;
+    static MyFizzBuzzProgram::_fizzbuzz fizzbuzz;
+    static MyFizzBuzzProgram::_modulo modulo;
+    static MyFizzBuzzProgram::_nope nope;
+    static MyFizzBuzzProgram::_three three;
+    static MyFizzBuzzProgram::_zero zero;
+private:
+    static fizzbuzz_ops<MyFizzBuzzProgram::Int32> __fizzbuzz_ops;
 };
 } // examples
 } // fizzbuzz

--- a/examples/fizzbuzz/cpp-src/gen/examples/fizzbuzz/mg-src/fizzbuzz.hpp
+++ b/examples/fizzbuzz/cpp-src/gen/examples/fizzbuzz/mg-src/fizzbuzz.hpp
@@ -7,52 +7,49 @@ namespace fizzbuzz {
 namespace mg_src {
 namespace fizzbuzz {
 struct MyFizzBuzzProgram {
-private:
-    struct dummy_struct {};
-public:
+    struct _buzz;
+    struct _doFizzBuzz;
+    struct _five;
+    struct _fizz;
+    struct _fizzbuzz;
+    struct _modulo;
+    struct _nope;
+    struct _three;
+    struct _zero;
     typedef basic_types::Int32 Int32;
-    typedef fizzbuzz_ops<dummy_struct>::FizzBuzz FizzBuzz;
-    
+    typedef fizzbuzz_ops<Int32>::FizzBuzz FizzBuzz;
     struct _buzz {
         MyFizzBuzzProgram::FizzBuzz operator()();
     };
 
-    
     struct _doFizzBuzz {
         MyFizzBuzzProgram::FizzBuzz operator()(const MyFizzBuzzProgram::Int32& i);
     };
 
-    
     struct _five {
         MyFizzBuzzProgram::Int32 operator()();
     };
 
-    
     struct _fizz {
         MyFizzBuzzProgram::FizzBuzz operator()();
     };
 
-    
     struct _fizzbuzz {
         MyFizzBuzzProgram::FizzBuzz operator()();
     };
 
-    
     struct _modulo {
         MyFizzBuzzProgram::Int32 operator()(const MyFizzBuzzProgram::Int32& a, const MyFizzBuzzProgram::Int32& modulus);
     };
 
-    
     struct _nope {
         MyFizzBuzzProgram::FizzBuzz operator()();
     };
 
-    
     struct _three {
         MyFizzBuzzProgram::Int32 operator()();
     };
 
-    
     struct _zero {
         MyFizzBuzzProgram::Int32 operator()();
     };

--- a/examples/while_loop/Makefile
+++ b/examples/while_loop/Makefile
@@ -1,0 +1,24 @@
+TARGET := $(shell basename `pwd`).bin
+
+.PHONY: all clean setup
+
+BIN_DIR := bin
+CPP_SOURCE_DIR := cpp-src
+CPP_SOURCES := $(shell find $(CPP_SOURCE_DIR) -name "*.cpp")
+
+CC := clang++
+CCFLAGS := -std=c++20 -I$(CPP_SOURCE_DIR)
+
+MKDIR := @mkdir
+RM := @rm
+
+all: setup
+	g++ $(CCFLAGS) $(CPP_SOURCES) -o $(BIN_DIR)/$(TARGET)
+	@echo $(TARGET)
+	@echo $(CPP_SOURCES)
+
+setup:
+	$(MKDIR) -p $(BIN_DIR)
+
+clean:
+	$(RM) -r $(BIN_DIR)

--- a/examples/while_loop/cpp-src/base.hpp
+++ b/examples/while_loop/cpp-src/base.hpp
@@ -1,0 +1,59 @@
+#include <string>
+
+template <typename _Context, typename _State, class _cond, class _body>
+struct while_ops {
+    typedef _State State;
+    typedef _Context Context;
+
+    struct fop_cond {
+        inline bool operator()(const State &state, const Context &context) {
+            return ext_cond(state, context);
+        }
+
+        private:
+            _cond ext_cond;
+    };
+
+    struct fop_body {
+        inline void operator()(State &state, const Context &context) {
+            ext_body(state, context);
+        }
+
+        private:
+            _body ext_body;
+    };
+
+    inline void repeat(State &state, const Context &context) {
+        while (while_ops::cond(state, context)) {
+            while_ops::body(state, context);
+        }
+    }
+
+    private:
+        fop_cond cond;
+        fop_body body;
+};
+
+struct int16_utils {
+    typedef short Int16;
+
+    inline Int16 one() { return 1; }
+    inline Int16 add(const Int16 a, const Int16 b) {
+        return a + b;
+    }
+    inline bool isLowerThan(const Int16 a, const Int16 b) {
+        return a < b;
+    }
+};
+
+struct int32_utils {
+    typedef int Int32;
+
+    inline Int32 one() { return 1; }
+    inline Int32 add(const Int32 a, const Int32 b) {
+        return a + b;
+    }
+    inline bool isLowerThan(const Int32 a, const Int32 b) {
+        return a < b;
+    }
+};

--- a/examples/while_loop/cpp-src/gen/examples/while_loop/mg-src/while_loop.cpp
+++ b/examples/while_loop/cpp-src/gen/examples/while_loop/mg-src/while_loop.cpp
@@ -1,0 +1,51 @@
+#include "gen/examples/while_loop/mg-src/while_loop.hpp"
+
+
+namespace examples {
+namespace while_loop {
+namespace mg_src {
+namespace while_loop {
+    int16_utils IterationProgram::__int16_utils;
+    int32_utils IterationProgram::__int32_utils;
+    IterationProgram::_add IterationProgram::add;
+    IterationProgram::_increment IterationProgram::increment;
+    IterationProgram::_isLowerThan IterationProgram::isLowerThan;
+    IterationProgram::_one IterationProgram::one;
+    IterationProgram::_repeat IterationProgram::repeat;
+    while_ops<IterationProgram::Int16, IterationProgram::Int16, IterationProgram::_isLowerThan, IterationProgram::_increment> IterationProgram::__while_ops;
+    while_ops<IterationProgram::Int32, IterationProgram::Int32, IterationProgram::_isLowerThan, IterationProgram::_increment> IterationProgram::__while_ops0;
+    IterationProgram::Int16 IterationProgram::_add::operator()(const IterationProgram::Int16& a, const IterationProgram::Int16& b) {
+        return __int16_utils.add(a, b);
+    };
+    IterationProgram::Int32 IterationProgram::_add::operator()(const IterationProgram::Int32& a, const IterationProgram::Int32& b) {
+        return __int32_utils.add(a, b);
+    };
+    void IterationProgram::_increment::operator()(IterationProgram::Int16& counter, const IterationProgram::Int16& bound) {
+        counter = IterationProgram::add(counter, IterationProgram::one.operator()<Int16>());
+    };
+    void IterationProgram::_increment::operator()(IterationProgram::Int32& counter, const IterationProgram::Int32& bound) {
+        counter = IterationProgram::add(counter, IterationProgram::one.operator()<Int32>());
+    };
+    bool IterationProgram::_isLowerThan::operator()(const IterationProgram::Int16& a, const IterationProgram::Int16& b) {
+        return __int16_utils.isLowerThan(a, b);
+    };
+    bool IterationProgram::_isLowerThan::operator()(const IterationProgram::Int32& a, const IterationProgram::Int32& b) {
+        return __int32_utils.isLowerThan(a, b);
+    };
+
+    void IterationProgram::_repeat::operator()(IterationProgram::Int16& s, const IterationProgram::Int16& c) {
+        return __while_ops.repeat(s, c);
+    };
+    void IterationProgram::_repeat::operator()(IterationProgram::Int32& s, const IterationProgram::Int32& c) {
+        return __while_ops0.repeat(s, c);
+    };
+    void IterationProgram::one0(IterationProgram::Int16& o) {
+        o = __int16_utils.one();
+    };
+    void IterationProgram::one0(IterationProgram::Int32& o) {
+        o = __int32_utils.one();
+    };
+} // examples
+} // while_loop
+} // mg_src
+} // while_loop

--- a/examples/while_loop/cpp-src/gen/examples/while_loop/mg-src/while_loop.hpp
+++ b/examples/while_loop/cpp-src/gen/examples/while_loop/mg-src/while_loop.hpp
@@ -1,0 +1,70 @@
+#include "base.hpp"
+#include <cassert>
+
+
+namespace examples {
+namespace while_loop {
+namespace mg_src {
+namespace while_loop {
+struct IterationProgram {
+private:
+    struct dummy_struct {};
+    struct dummy_struct0 {};
+    struct dummy_struct1 {};
+    struct dummy_struct2 {};
+public:
+    typedef int16_utils::Int16 Int16;
+    typedef int32_utils::Int32 Int32;
+    
+    struct _add {
+        IterationProgram::Int16 operator()(const IterationProgram::Int16& a, const IterationProgram::Int16& b);
+        IterationProgram::Int32 operator()(const IterationProgram::Int32& a, const IterationProgram::Int32& b);
+    };
+
+    
+    struct _increment {
+        void operator()(IterationProgram::Int16& counter, const IterationProgram::Int16& bound);
+        void operator()(IterationProgram::Int32& counter, const IterationProgram::Int32& bound);
+    };
+
+    
+    struct _isLowerThan {
+        bool operator()(const IterationProgram::Int16& a, const IterationProgram::Int16& b);
+        bool operator()(const IterationProgram::Int32& a, const IterationProgram::Int32& b);
+    };
+
+    
+    struct _one {
+        template <typename T>
+        inline T operator()() {
+            T o;
+            IterationProgram::one0(o);
+            return o;
+        };
+    };
+
+    
+    struct _repeat {
+        void operator()(IterationProgram::Int16& s, const IterationProgram::Int16& c);
+        void operator()(IterationProgram::Int32& s, const IterationProgram::Int32& c);
+    };
+
+private:
+    static void one0(IterationProgram::Int16& o);
+    static void one0(IterationProgram::Int32& o);
+    static int16_utils __int16_utils;
+    static int32_utils __int32_utils;
+public:
+    static IterationProgram::_add add;
+    static IterationProgram::_increment increment;
+    static IterationProgram::_isLowerThan isLowerThan;
+    static IterationProgram::_one one;
+    static IterationProgram::_repeat repeat;
+private:
+    static while_ops<IterationProgram::Int16, IterationProgram::Int16, IterationProgram::_isLowerThan, IterationProgram::_increment> __while_ops;
+    static while_ops<IterationProgram::Int32, IterationProgram::Int32, IterationProgram::_isLowerThan, IterationProgram::_increment> __while_ops0;
+};
+} // examples
+} // while_loop
+} // mg_src
+} // while_loop

--- a/examples/while_loop/cpp-src/gen/examples/while_loop/mg-src/while_loop.hpp
+++ b/examples/while_loop/cpp-src/gen/examples/while_loop/mg-src/while_loop.hpp
@@ -7,33 +7,28 @@ namespace while_loop {
 namespace mg_src {
 namespace while_loop {
 struct IterationProgram {
-private:
-    struct dummy_struct {};
-    struct dummy_struct0 {};
-    struct dummy_struct1 {};
-    struct dummy_struct2 {};
-public:
-    typedef int16_utils::Int16 Int16;
+    struct _add;
+    struct _increment;
+    struct _isLowerThan;
+    struct _one;
+    struct _repeat;
     typedef int32_utils::Int32 Int32;
-    
+    typedef int16_utils::Int16 Int16;
     struct _add {
         IterationProgram::Int16 operator()(const IterationProgram::Int16& a, const IterationProgram::Int16& b);
         IterationProgram::Int32 operator()(const IterationProgram::Int32& a, const IterationProgram::Int32& b);
     };
 
-    
     struct _increment {
         void operator()(IterationProgram::Int16& counter, const IterationProgram::Int16& bound);
         void operator()(IterationProgram::Int32& counter, const IterationProgram::Int32& bound);
     };
 
-    
     struct _isLowerThan {
         bool operator()(const IterationProgram::Int16& a, const IterationProgram::Int16& b);
         bool operator()(const IterationProgram::Int32& a, const IterationProgram::Int32& b);
     };
 
-    
     struct _one {
         template <typename T>
         inline T operator()() {
@@ -43,7 +38,6 @@ public:
         };
     };
 
-    
     struct _repeat {
         void operator()(IterationProgram::Int16& s, const IterationProgram::Int16& c);
         void operator()(IterationProgram::Int32& s, const IterationProgram::Int32& c);

--- a/examples/while_loop/cpp-src/main.cpp
+++ b/examples/while_loop/cpp-src/main.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include "gen/examples/while_loop/mg-src/while_loop.hpp"
+
+int main(int argc, char **argv) {
+    --argc;
+    if (argc < 3) {
+        std::cerr << "Usage: " << argv[0] << " <nb bits> <start> <bound>"
+                  << std::endl;
+        return 1;
+    }
+
+    int nb_bits = atoi(argv[1]);
+
+    // TODO: add a base build path to compiler args to avoid having so many
+    // nested useless folders when compiling from somewhere else.
+    examples::while_loop::mg_src::while_loop::IterationProgram P;
+
+    int32_utils::Int32 iterator32, bound32;
+    int16_utils::Int16 iterator16, bound16;
+
+    if (nb_bits == 32) {
+        iterator32 = atoi(argv[2]);
+        bound32 = atoi(argv[3]);
+        P.repeat(iterator32, bound32);
+        std::cout << "32-bit iterator: " << iterator32 << std::endl;
+    }
+    else if (nb_bits == 16) {
+        iterator16 = atoi(argv[2]);
+        bound16 = atoi(argv[3]);
+        P.repeat(iterator16, bound16);
+        std::cout << "16-bit iterator: " << iterator16 << std::endl;
+    }
+    else {
+        std::cout << "<nb bits> must be 16 or 32" << std::endl;
+    }
+}

--- a/examples/while_loop/mg-src/while_loop.mg
+++ b/examples/while_loop/mg-src/while_loop.mg
@@ -1,0 +1,51 @@
+package examples.while_loop.mg-src.while_loop;
+
+implementation WhileLoop = external C++ base.while_ops {
+    require type Context;
+    require type State;
+    require predicate cond(s: State, c: Context);
+    require procedure body(upd s: State, obs c: Context);
+    procedure repeat(upd s: State, obs c: Context);
+}
+
+implementation Utils = {
+    require type IntLike;
+    require function add(a: IntLike, b: IntLike): IntLike;
+    require function one(): IntLike;
+
+    procedure increment(upd counter: IntLike, obs bound: IntLike) = {
+        counter = add(counter, one());
+    }
+}
+
+signature IntLikeOps = {
+    type IntLike;
+
+    function one(): IntLike;
+    function add(a: IntLike, b: IntLike): IntLike;
+    predicate isLowerThan(a: IntLike, b: IntLike);
+}
+
+// TODO: write with a signature cast & renamings
+implementation Int16Utils = external C++ base.int16_utils IntLikeOps[IntLike => Int16];
+
+implementation Int32Utils = external C++ base.int32_utils IntLikeOps[IntLike => Int32];
+
+program IterationProgram = {
+    use Int16Utils;
+    use Int32Utils;
+
+    use Utils[IntLike => Int16];
+    use Utils[IntLike => Int32];
+
+    use WhileLoop[ Context => Int32
+                 , State => Int32
+                 , cond => isLowerThan
+                 , body => increment
+                 ];
+    use WhileLoop[ Context => Int16
+                 , State => Int16
+                 , cond => isLowerThan
+                 , body => increment
+                 ];
+}

--- a/src/lib/Cxx/Syntax.hs
+++ b/src/lib/Cxx/Syntax.hs
@@ -10,6 +10,7 @@ module Cxx.Syntax (
   , CxxInclude
   , CxxLambdaCaptureDefault (..)
   , CxxModule (..)
+  , CxxModuleMemberType (..)
   , CxxNamespaceName
   , CxxObject (..)
   , CxxOutMode (..)
@@ -22,6 +23,7 @@ module Cxx.Syntax (
   , CxxVar (..)
     -- * name-related utils
   , CxxName
+  , cxxFunctionCallOperatorName
   , mkClassMemberCxxType
   , mkCxxClassMemberAccess
   , mkCxxName
@@ -65,6 +67,10 @@ data CxxName = -- | A simple identifier
                -- | An identifier corresponding to a member of an object
              | CxxObjectMemberName CxxName CxxName
                deriving (Eq, Ord, Show)
+
+-- | The C++ name corresponding to the function call operator \'operator()\'.
+cxxFunctionCallOperatorName :: CxxName
+cxxFunctionCallOperatorName = CxxName "operator()"
 
 -- TODO: handle operators and "invalid C++ names", maybe?
 -- | Makes a CxxName out of a Name. The function may throw an error if the name
@@ -247,7 +253,7 @@ data CxxModule =
 type CxxModuleName = CxxName
 type CxxNamespaceName = CxxName
 
--- | The equivalent of a Magnolia declaration in C++.
+-- | The equivalent of a set of Magnolia declarations in C++.
 data CxxDef
     -- | A C++ empty module. This is used in order to define dummy data
     -- structures for parameterizing external templated modules with in order
@@ -258,19 +264,33 @@ data CxxDef
   | CxxTypeDef CxxName CxxName
     -- | A C++ function definition.
   | CxxFunctionDef CxxFunctionDef
-    -- | An instance of an external module/struct. Modules will carry such
-    --   references in order to appropriately call externally defined callables.
-    --   TODO: external references may be templated with required types,
-    --         requiring thus a specialization. This is not handled yet.
-  | CxxExternalInstance CxxObject
+    -- | A nested module definition.
+  | CxxNestedModule CxxModule
+    -- | An instance of a module/struct. Modules will carry such references in
+    -- order to appropriately call callables defined in other structs if
+    -- necessary.
+  | CxxInstance CxxObject
     deriving (Eq, Show)
 
-data CxxObject = CxxObject CxxType CxxName
+data CxxObject = CxxObject { _cxxObjectModuleMemberType :: CxxModuleMemberType
+                           , _cxxObjectType :: CxxType
+                           , _cxxObjectName :: CxxName
+                          }
                  deriving (Eq, Ord, Show)
+
+-- TODO: is this needed?
+-- | Used to differentiate static member objects and functions from members
+-- dependent on struct/class instances.
+data CxxModuleMemberType = CxxStaticMember | CxxNonStaticMember
+                           deriving (Eq, Ord, Show)
 
 instance Ord CxxDef where
   -- Order is as follows:
-  -- dummy module < type < function < external instance
+  --  * dummy module definitions
+  --  * type definitions
+  --  * nested module definitions
+  --  * function definitions
+  --  * external instances
   compare def1 def2 = case def1 of
     CxxDummyModule cxxN1 -> case def2 of
       CxxDummyModule cxxN2 -> cxxN1 `compare` cxxN2
@@ -279,15 +299,21 @@ instance Ord CxxDef where
       CxxDummyModule {} -> GT
       CxxTypeDef src2 tgt2 ->
         src1 `compare` src2 <> tgt1 `compare` tgt2
+      _ -> LT
+    CxxNestedModule cxxMod1 -> case def2 of
+      CxxDummyModule {} -> GT
+      CxxTypeDef {} -> GT
+      CxxNestedModule cxxMod2 -> cxxMod1 `compare` cxxMod2 -- TODO
       CxxFunctionDef {} -> LT
-      CxxExternalInstance {} -> LT
+      CxxInstance {} -> LT
     CxxFunctionDef cxxFn1 -> case def2 of
       CxxDummyModule {} -> GT
       CxxTypeDef {} -> GT
+      CxxNestedModule {} -> GT
       CxxFunctionDef cxxFn2 -> cxxFn1 `compare` cxxFn2
-      CxxExternalInstance {} -> LT
-    CxxExternalInstance cxxObj1 -> case def2 of
-      CxxExternalInstance cxxObj2 ->
+      CxxInstance {} -> LT
+    CxxInstance cxxObj1 -> case def2 of
+      CxxInstance cxxObj2 ->
         cxxObj1 `compare` cxxObj2
       _ -> GT
 
@@ -297,7 +323,10 @@ instance Ord CxxDef where
 
 -- | The equivalent of a concrete Magnolia function definition in C++.
 data CxxFunctionDef =
-  CxxFunction { -- | Whether the function should be inlined. This field is set
+  CxxFunction { -- | Whether the function is static. This field should now be
+                -- set to 'CxxStaticMember' for every function definition.
+                _cxxFnModuleMemberType :: CxxModuleMemberType
+              , -- | Whether the function should be inlined. This field is set
                 -- to true typically when the function is a simple wrapping
                 -- over an external implementation.
                 _cxxFnIsInline :: Bool
@@ -385,7 +414,7 @@ data CxxType = CxxVoid
              | CxxCustomTemplatedType CxxName [CxxTemplateParameter]
                deriving (Eq, Ord, Show)
 
-type CxxTemplateParameter = CxxName
+type CxxTemplateParameter = CxxType
 
 data CxxAccessSpec = CxxPublic | CxxPrivate | CxxProtected
                      deriving (Eq, Ord, Show)
@@ -396,6 +425,7 @@ data CxxAccessSpec = CxxPublic | CxxPrivate | CxxProtected
 
 -- | An enumeration of possible output modes for the PrettyCxx typeclass.
 data CxxOutMode = CxxHeader | CxxImplementation
+                  deriving Eq
 
 -- | Pretty prints a C++ package as an implementation file or as a header
 -- file. A base path can be provided to derive includes correctly.
@@ -431,19 +461,23 @@ prettyCxxInclude mbasePath (CxxInclude headerLoc filePath) =
     RelativeMgDir -> dquotes (p realFilePath)
     SystemDir -> langle <> p filePath <> rangle
 
+-- TODO: pretty print template parameters
 prettyCxxModule :: CxxOutMode -> CxxModule -> Doc ann
 prettyCxxModule CxxHeader (CxxModule namespaces name defs) =
   -- 1. Open namespaces
-  align (vsep (map (\ns -> "namespace" <+> p ns <+> "{") namespaces)) <>
-  line <>
+  ifNotNull namespaces
+    (align (vsep (map (\ns -> "namespace" <+> p ns <+> "{") namespaces)) <>
+     line) <>
   -- 2. Build class / struct header
   "struct" <+> p name <+> "{" <> line <>
   -- 3. Input class / struct definitions
-  prettyStructContent CxxPublic sortedDefs <> line <>
+  prettyStructContent CxxPublic sortedDefs <>
   "};" <> line <>
   -- 4. Close namespaces
   align (vsep (map (\ns -> "} //" <+> p ns) namespaces))
   where
+    ifNotNull es doc = if not (null es) then doc else ""
+
     sortedDefs = L.sortOn snd defs
 
     prettyDef prevAccessSpec accessSpec def =
@@ -457,44 +491,93 @@ prettyCxxModule CxxHeader (CxxModule namespaces name defs) =
       prettyDef prevAccessSpec accessSpec def <> line <>
       prettyStructContent accessSpec ds
 
-prettyCxxModule CxxImplementation (CxxModule namespaces cxxModuleName defs) =
+prettyCxxModule CxxImplementation
+                (CxxModule namespaces cxxModuleName
+                           defsWithAccessSpec) =
   -- 1. Open namespaces
-  align (vsep (map (\ns -> "namespace" <+> p ns <+> "{") namespaces)) <>
-  line <>
+  ifNotNull namespaces
+  (align (vsep (map (\ns -> "namespace" <+> p ns <+> "{") namespaces)) <>
+   line) <>
   -- 2. Build class / struct definitions
-  indent cxxIndent
-    (vsep (map ((<> ";") . prettyCxxFnDef CxxImplementation) defsToImpl)) <>
-    line <>
-  -- 3. Close namespaces
-  align (vsep (map (\ns -> "} //" <+> p ns) namespaces))
+  -- 2.1 Instantiate objects
+  ifNotNull objectsToImpl (indent cxxIndent
+    (vsep (map (prettyCxxObject CxxImplementation) objectsToImpl)) <> line) <>
+  -- 2.2 Implement nested modules
+  ifNotNull nestedModulesToImpl
+            (vsep (map (prettyCxxModule CxxImplementation)
+                       nestedModulesToImpl) <> line) <>
+  -- 2.3 Implement functions
+  ifNotNull functionsToImpl
+    (indent cxxIndent
+      (vsep (map ((<> ";") . prettyCxxFnDef CxxImplementation)
+                 functionsToImpl))) <>
+  -- 3. Close namespaces if some were opened
+  ifNotNull namespaces
+    (line <> align (vsep (map (\ns -> "} //" <+> p ns) namespaces)))
   where
-    defsToImpl = L.sort $ map mkImplName $
-      filter (not . _cxxFnIsInline) $
-        foldl (\acc -> getFnDefs acc . snd) [] defs
+    ifNotNull es doc = if not (null es) then doc else ""
 
-    mkImplName cxxFn =
+    (_, defs) = unzip defsWithAccessSpec
+    (allFunctions, allNestedModules, allObjects) =
+      foldl accDifferentDefs ([], [], []) defs
+
+    functionsToImpl = L.sort $ map mkFunctionImplName $
+      filter (not . _cxxFnIsInline) allFunctions
+    nestedModulesToImpl = L.sort $ map mkNestedModuleImplName allNestedModules
+    objectsToImpl = L.sort $ map mkObjectImplName allObjects
+
+    mkFunctionImplName cxxFn =
       let newName = mkCxxClassMemberAccess (CxxCustomType cxxModuleName)
                                            (_cxxFnName cxxFn)
       in cxxFn { _cxxFnName = newName}
 
-    getFnDefs acc cxxDef = case cxxDef of
-      CxxFunctionDef cxxFn -> cxxFn:acc
+    mkNestedModuleImplName cxxMod =
+      let newName = mkCxxClassMemberAccess (CxxCustomType cxxModuleName)
+                                           (_cxxModuleName cxxMod)
+      in cxxMod { _cxxModuleName = newName }
+
+    mkObjectImplName cxxObj =
+      let newName = mkCxxClassMemberAccess (CxxCustomType cxxModuleName)
+                                           (_cxxObjectName cxxObj)
+      in cxxObj { _cxxObjectName = newName }
+
+    accDifferentDefs :: ([CxxFunctionDef], [CxxModule], [CxxObject])
+                     -> CxxDef
+                     -> ([CxxFunctionDef], [CxxModule], [CxxObject])
+    accDifferentDefs acc@(cxxFns, cxxMods, cxxObjs) cxxDef = case cxxDef of
+      CxxFunctionDef cxxFn -> (cxxFn:cxxFns, cxxMods, cxxObjs)
+      CxxNestedModule cxxMod -> (cxxFns, cxxMod:cxxMods, cxxObjs)
+      CxxInstance cxxObj -> (cxxFns, cxxMods, cxxObj:cxxObjs)
       _ -> acc
 
 prettyCxxDef :: CxxOutMode -> CxxDef -> Doc ann
 prettyCxxDef _ (CxxTypeDef sourceName targetName) =
-  "typedef" <+> p sourceName <+> p targetName <> ";"
+    "typedef" <+> p sourceName <+> p targetName <> ";"
 prettyCxxDef cxxOutMode (CxxFunctionDef fn) =
   prettyCxxFnDef cxxOutMode fn <> ";"
 prettyCxxDef _ (CxxDummyModule cxxName) =
   "struct" <+> p cxxName <+> lbrace <> rbrace <> semi
-prettyCxxDef _ (CxxExternalInstance (CxxObject ty name)) =
-  p ty <+> p name <> ";"
+prettyCxxDef cxxOutMode (CxxNestedModule cxxMod) =
+  prettyCxxModule cxxOutMode cxxMod
+prettyCxxDef cxxOutMode (CxxInstance cxxObject) =
+  prettyCxxObject cxxOutMode cxxObject
+
+prettyCxxObject :: CxxOutMode -> CxxObject -> Doc ann
+prettyCxxObject cxxOutMode (CxxObject cxxMemberTy ty name) =
+  let instDoc = p ty <+> p name <> ";"
+  in case cxxMemberTy of
+      CxxStaticMember -> case cxxOutMode of
+        CxxHeader -> "static" <+> instDoc
+        CxxImplementation -> instDoc
+      CxxNonStaticMember -> instDoc
 
 prettyCxxFnDef :: CxxOutMode -> CxxFunctionDef -> Doc ann
 prettyCxxFnDef cxxOutMode
-              (CxxFunction isInline name templateParams params retTy body) =
+              (CxxFunction cxxModuleMemberType isInline name templateParams
+                           params retTy body) =
   (if isTemplated then pTemplateParams <> line else "") <>
+  (if cxxModuleMemberType == CxxStaticMember && cxxOutMode == CxxHeader
+   then "static " else "") <>
   (if isInline then "inline " else "") <> p retTy <+> p name <> "(" <>
   hsep (punctuate comma (map p params)) <> ")" <>
   case cxxOutMode of

--- a/tests/self-contained-codegen/inputs/externalTests.mg
+++ b/tests/self-contained-codegen/inputs/externalTests.mg
@@ -26,3 +26,19 @@ program ProgramThatReliesOnWrongBackendCallable = {
     use MgImplType_Cxx;
     use MgImplCallable_JS;
 }
+
+implementation CircularDependency1 = external C++ IncludeFile.circular_dep1 {
+    require type A;
+    type B;
+}
+
+implementation CircularDependency2 = external C++ IncludeFile.circular_dep2 {
+    type A;
+    require type B;
+}
+
+// should fail
+program CircularDependency = {
+    use CircularDependency1;
+    use CircularDependency2;
+}

--- a/tests/self-contained-codegen/inputs/generalTranslationTests.mg
+++ b/tests/self-contained-codegen/inputs/generalTranslationTests.mg
@@ -10,8 +10,7 @@ implementation MgImpl = external C++ E.ExternalImplementation {
     function _+_(lhs: X, rhs: X): X;
 };
 
-implementation MgSomeTypes = external C++ E.ExternalImplementationSomeTypes {
-    require type A;
+implementation MgSomeType = external C++ E.ExternalImplementationSomeType {
     type B;
 };
 
@@ -35,7 +34,7 @@ implementation Helper = {
 
 program P = {
     use MgImpl[mkY => _mkY];
-    use MgSomeTypes[A => Y, B => X];
+    use MgSomeType[B => X];
     use MgSomeMoreTypesAndFunctions[A => Y, B => X, C => Y, f => mkX];
     use Helper;
 

--- a/tests/self-contained-codegen/outputs/externalTests.mg.out
+++ b/tests/self-contained-codegen/outputs/externalTests.mg.out
@@ -1,3 +1,5 @@
 tests/self-contained-codegen/inputs/externalTests.mg:21:9: Error in tests.self-contained-codegen.inputs.externalTests.ProgramThatReliesOnWrongBackendType: attempted to generate C++ code relying on external type TyStruct.T but it is declared as having a JavaScript backend
 
 tests/self-contained-codegen/inputs/externalTests.mg:27:9: Error in tests.self-contained-codegen.inputs.externalTests.ProgramThatReliesOnWrongBackendCallable: attempted to generate C++ code relying on external function FnStruct.identity but it is declared as having a JavaScript backend
+
+tests/self-contained-codegen/inputs/externalTests.mg:41:1: Error in tests.self-contained-codegen.inputs.externalTests.CircularDependency: can not sort types A, B topologically

--- a/tests/self-contained-codegen/outputs/generalTranslationTests.mg.out
+++ b/tests/self-contained-codegen/outputs/generalTranslationTests.mg.out
@@ -16,25 +16,54 @@ public:
     typedef ExternalImplementation<dummy_struct>::Y Y;
     typedef ExternalImplementationSomeMoreTypes<dummy_struct, dummy_struct0, dummy_struct1, dummy_struct2>::AConcreteType AConcreteType;
     typedef ExternalImplementationSomeTypes<dummy_struct>::B X;
-    P::Y _mkY();
-    void all_statements(const P::X& x_obs, P::X& x_upd, P::X& x_out);
-    P::X binary_add(const P::X& lhs, const P::X& rhs);
-    P::X call_f_overloaded_on_return_type();
-    void helper_assign(P::X& x_out);
-    P::X mkX();
-    void some_f_overloaded_on_return_type0(P::X& o);
-    void some_f_overloaded_on_return_type0(P::Y& o);
-    template <typename T>
-    inline T some_f_overloaded_on_return_type() {
-        T o;
-        some_f_overloaded_on_return_type0(o);
-        return o;
+    struct __+_ {
+        P::X operator()(const P::X& lhs, const P::X& rhs);
     };
-private:
-    ExternalImplementation<X> __ExternalImplementation;
-    ExternalImplementationSomeMoreTypes<Y, X, Y, mkX> __ExternalImplementationSomeMoreTypes;
-    ExternalImplementationSomeTypes<Y> __ExternalImplementationSomeTypes;
 
+    struct __mkY {
+        P::Y operator()();
+    };
+
+    struct _all_statements {
+        void operator()(const P::X& x_obs, P::X& x_upd, P::X& x_out);
+    };
+
+    struct _call_f_overloaded_on_return_type {
+        P::X operator()();
+    };
+
+    struct _helper_assign {
+        void operator()(P::X& x_out);
+    };
+
+    struct _mkX {
+        P::X operator()();
+    };
+
+    struct _some_f_overloaded_on_return_type {
+        template <typename T>
+        inline T operator()() {
+            T o;
+            P::some_f_overloaded_on_return_type0(o);
+            return o;
+        };
+    };
+
+private:
+    static void some_f_overloaded_on_return_type0(P::X& o);
+    static void some_f_overloaded_on_return_type0(P::Y& o);
+public:
+    static P::__+_ binary_add;
+    static P::__mkY _mkY;
+    static P::_all_statements all_statements;
+    static P::_call_f_overloaded_on_return_type call_f_overloaded_on_return_type;
+    static P::_helper_assign helper_assign;
+    static P::_mkX mkX;
+    static P::_some_f_overloaded_on_return_type some_f_overloaded_on_return_type;
+private:
+    static ExternalImplementation<P::X> __ExternalImplementation;
+    static ExternalImplementationSomeMoreTypes<P::Y, P::X, P::Y, P::_mkX> __ExternalImplementationSomeMoreTypes;
+    static ExternalImplementationSomeTypes<P::Y> __ExternalImplementationSomeTypes;
 };
 } // tests
 } // self_contained_codegen
@@ -46,7 +75,6 @@ namespace self_contained_codegen {
 namespace inputs {
 namespace generalTranslationTests {
 struct P2 {
-
 };
 } // tests
 } // self_contained_codegen
@@ -59,10 +87,23 @@ namespace tests {
 namespace self_contained_codegen {
 namespace inputs {
 namespace generalTranslationTests {
-    P::Y P::_mkY() {
+    P::__+_ P::binary_add;
+    P::__mkY P::_mkY;
+    P::_all_statements P::all_statements;
+    P::_call_f_overloaded_on_return_type P::call_f_overloaded_on_return_type;
+    P::_helper_assign P::helper_assign;
+    P::_mkX P::mkX;
+    P::_some_f_overloaded_on_return_type P::some_f_overloaded_on_return_type;
+    ExternalImplementation<P::X> P::__ExternalImplementation;
+    ExternalImplementationSomeMoreTypes<P::Y, P::X, P::Y, P::_mkX> P::__ExternalImplementationSomeMoreTypes;
+    ExternalImplementationSomeTypes<P::Y> P::__ExternalImplementationSomeTypes;
+    P::X P::__+_::operator()(const P::X& lhs, const P::X& rhs) {
+        return __ExternalImplementation.binary_add(lhs, rhs);
+    };
+    P::Y P::__mkY::operator()() {
         return __ExternalImplementation.mkY();
     };
-    void P::all_statements(const P::X& x_obs, P::X& x_upd, P::X& x_out) {
+    void P::_all_statements::operator()(const P::X& x_obs, P::X& x_upd, P::X& x_out) {
         x_out = x_obs;
         x_out = [=, this]() {
             return P::mkX();
@@ -89,18 +130,16 @@ namespace generalTranslationTests {
             ;
         }
     };
-    P::X P::binary_add(const P::X& lhs, const P::X& rhs) {
-        return __ExternalImplementation.binary_add(lhs, rhs);
+    P::X P::_call_f_overloaded_on_return_type::operator()() {
+        return P::some_f_overloaded_on_return_type.operator()<X>();
     };
-    P::X P::call_f_overloaded_on_return_type() {
-        return P::some_f_overloaded_on_return_type<X>();
-    };
-    void P::helper_assign(P::X& x_out) {
+    void P::_helper_assign::operator()(P::X& x_out) {
         x_out = P::mkX();
     };
-    P::X P::mkX() {
+    P::X P::_mkX::operator()() {
         return __ExternalImplementation.mkX();
     };
+
     void P::some_f_overloaded_on_return_type0(P::X& o) {
         o = P::mkX();
     };
@@ -116,7 +155,7 @@ namespace tests {
 namespace self_contained_codegen {
 namespace inputs {
 namespace generalTranslationTests {
-    
+
 } // tests
 } // self_contained_codegen
 } // inputs

--- a/tests/self-contained-codegen/outputs/generalTranslationTests.mg.out
+++ b/tests/self-contained-codegen/outputs/generalTranslationTests.mg.out
@@ -7,15 +7,16 @@ namespace self_contained_codegen {
 namespace inputs {
 namespace generalTranslationTests {
 struct P {
-private:
-    struct dummy_struct {};
-    struct dummy_struct0 {};
-    struct dummy_struct1 {};
-    struct dummy_struct2 {};
-public:
-    typedef ExternalImplementation<dummy_struct>::Y Y;
-    typedef ExternalImplementationSomeMoreTypes<dummy_struct, dummy_struct0, dummy_struct1, dummy_struct2>::AConcreteType AConcreteType;
-    typedef ExternalImplementationSomeTypes<dummy_struct>::B X;
+    struct __+_;
+    struct __mkY;
+    struct _all_statements;
+    struct _call_f_overloaded_on_return_type;
+    struct _helper_assign;
+    struct _mkX;
+    struct _some_f_overloaded_on_return_type;
+    typedef ExternalImplementationSomeType::B X;
+    typedef ExternalImplementation<X>::Y Y;
+    typedef ExternalImplementationSomeMoreTypes<Y, X, Y, _mkX>::AConcreteType AConcreteType;
     struct __+_ {
         P::X operator()(const P::X& lhs, const P::X& rhs);
     };
@@ -52,6 +53,7 @@ public:
 private:
     static void some_f_overloaded_on_return_type0(P::X& o);
     static void some_f_overloaded_on_return_type0(P::Y& o);
+    static ExternalImplementationSomeType __ExternalImplementationSomeType;
 public:
     static P::__+_ binary_add;
     static P::__mkY _mkY;
@@ -63,7 +65,6 @@ public:
 private:
     static ExternalImplementation<P::X> __ExternalImplementation;
     static ExternalImplementationSomeMoreTypes<P::Y, P::X, P::Y, P::_mkX> __ExternalImplementationSomeMoreTypes;
-    static ExternalImplementationSomeTypes<P::Y> __ExternalImplementationSomeTypes;
 };
 } // tests
 } // self_contained_codegen
@@ -87,6 +88,7 @@ namespace tests {
 namespace self_contained_codegen {
 namespace inputs {
 namespace generalTranslationTests {
+    ExternalImplementationSomeType P::__ExternalImplementationSomeType;
     P::__+_ P::binary_add;
     P::__mkY P::_mkY;
     P::_all_statements P::all_statements;
@@ -96,7 +98,6 @@ namespace generalTranslationTests {
     P::_some_f_overloaded_on_return_type P::some_f_overloaded_on_return_type;
     ExternalImplementation<P::X> P::__ExternalImplementation;
     ExternalImplementationSomeMoreTypes<P::Y, P::X, P::Y, P::_mkX> P::__ExternalImplementationSomeMoreTypes;
-    ExternalImplementationSomeTypes<P::Y> P::__ExternalImplementationSomeTypes;
     P::X P::__+_::operator()(const P::X& lhs, const P::X& rhs) {
         return __ExternalImplementation.binary_add(lhs, rhs);
     };


### PR DESCRIPTION
An additional example is added to the repository, corresponding to a
while_loop implemented in Magnolia for two different iteration types
(Int16 = short, Int32 = int).

We also fix a bug in the type checking phase that allowed merging
prototypes and bodies differently, sometimes producing callables with
different argument names than those used in the body of the callable.

One remaining caveat with this implementation of function requirements
is that calling a function overloaded solely on return type now requires
calling f.operator()<T>(…) explicitly, instead of the simpler f<T>().
There is a plan in place to fix that in the future.